### PR TITLE
feat(11): Add Manager scripts and scriptable objects

### DIFF
--- a/.editorconfig.txt
+++ b/.editorconfig.txt
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/DataManager.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/DataManager.cs
@@ -1,0 +1,86 @@
+// System
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+// Engine
+using UnityEngine;
+
+public class DataManager<T>
+{
+    // 파일 경로
+    private static string dataFilePath = Application.persistentDataPath + "/GameData.json";
+
+    [Serializable]
+    public class SerializableData
+    {
+        public int id;  // 식별자
+        public T data;   // 실제 데이터
+
+        public SerializableData(int id, T data)
+        {
+            this.id = id;
+            this.data = data;
+        }
+    }
+
+    public class DataSaver
+    {
+        // 데이터 리스트를 JSON 형식으로 변환하여 파일에서 관리
+        public static void SaveData(List<SerializableData> dataList)
+        {
+            string jsonData = JsonUtility.ToJson(dataList);
+            File.WriteAllText(dataFilePath, jsonData);
+        }
+    }
+
+    public class DataLoader
+    {
+        // 데이터 파일에서 데이터 리스트를 불러옴
+        public static List<SerializableData> LoadData()
+        {
+            List<SerializableData> dataList = new List<SerializableData>();
+
+            if (File.Exists(dataFilePath))
+            {
+                string jsonData = File.ReadAllText(dataFilePath);
+                dataList = JsonUtility.FromJson<List<SerializableData>>(jsonData);
+            }
+            else
+            {
+                Debug.LogWarning("불러올 데이터가 없습니다.");
+            }
+
+            return dataList;
+        }
+
+        // 데이터 리스트를 Dictionary로 변환하여 반환
+        public static Dictionary<int, T> GetDataDictionary(List<SerializableData> dataList)
+        {
+            Dictionary<int, T> dataDictionary = new Dictionary<int, T>();
+
+            foreach (var data in dataList)
+            {
+                dataDictionary[data.id] = data.data;
+            }
+
+            return dataDictionary;
+        }
+
+        // Dictionary에서 ID를 사용하여 데이터를 찾아 반환
+        public static T GetDataById(Dictionary<int, T> dataDictionary, int id)
+        {
+            T resultData;
+
+            if (dataDictionary.TryGetValue(id, out resultData))
+            {
+                return resultData;
+            }
+            else
+            {
+                Debug.LogWarning("ID에 해당하는 데이터를 찾을 수 없습니다.");
+                return default(T);
+            }
+        }
+    }
+}

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/DataManager.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/DataManager.cs
@@ -1,4 +1,4 @@
-// System
+ï»¿// System
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,14 +8,14 @@ using UnityEngine;
 
 public class DataManager<T>
 {
-    // ÆÄÀÏ °æ·Î
+    // íŒŒì¼ ê²½ë¡œ
     private static string dataFilePath = Application.persistentDataPath + "/GameData.json";
 
     [Serializable]
     public class SerializableData
     {
-        public int id;  // ½Äº°ÀÚ
-        public T data;   // ½ÇÁ¦ µ¥ÀÌÅÍ
+        public int id;  // ì‹ë³„ì
+        public T data;   // ì‹¤ì œ ë°ì´í„°
 
         public SerializableData(int id, T data)
         {
@@ -26,7 +26,7 @@ public class DataManager<T>
 
     public class DataSaver
     {
-        // µ¥ÀÌÅÍ ¸®½ºÆ®¸¦ JSON Çü½ÄÀ¸·Î º¯È¯ÇÏ¿© ÆÄÀÏ¿¡¼­ °ü¸®
+        // ë°ì´í„° ë¦¬ìŠ¤íŠ¸ë¥¼ JSON í˜•ì‹ìœ¼ë¡œ ë³€í™˜í•˜ì—¬ íŒŒì¼ì—ì„œ ê´€ë¦¬
         public static void SaveData(List<SerializableData> dataList)
         {
             string jsonData = JsonUtility.ToJson(dataList);
@@ -36,7 +36,7 @@ public class DataManager<T>
 
     public class DataLoader
     {
-        // µ¥ÀÌÅÍ ÆÄÀÏ¿¡¼­ µ¥ÀÌÅÍ ¸®½ºÆ®¸¦ ºÒ·¯¿È
+        // ë°ì´í„° íŒŒì¼ì—ì„œ ë°ì´í„° ë¦¬ìŠ¤íŠ¸ë¥¼ ë¶ˆëŸ¬ì˜´
         public static List<SerializableData> LoadData()
         {
             List<SerializableData> dataList = new List<SerializableData>();
@@ -48,13 +48,13 @@ public class DataManager<T>
             }
             else
             {
-                Debug.LogWarning("ºÒ·¯¿Ã µ¥ÀÌÅÍ°¡ ¾ø½À´Ï´Ù.");
+                Debug.LogWarning("ë¶ˆëŸ¬ì˜¬ ë°ì´í„°ê°€ ì—†ìŠµë‹ˆë‹¤.");
             }
 
             return dataList;
         }
 
-        // µ¥ÀÌÅÍ ¸®½ºÆ®¸¦ Dictionary·Î º¯È¯ÇÏ¿© ¹İÈ¯
+        // ë°ì´í„° ë¦¬ìŠ¤íŠ¸ë¥¼ Dictionaryë¡œ ë³€í™˜í•˜ì—¬ ë°˜í™˜
         public static Dictionary<int, T> GetDataDictionary(List<SerializableData> dataList)
         {
             Dictionary<int, T> dataDictionary = new Dictionary<int, T>();
@@ -67,7 +67,7 @@ public class DataManager<T>
             return dataDictionary;
         }
 
-        // Dictionary¿¡¼­ ID¸¦ »ç¿ëÇÏ¿© µ¥ÀÌÅÍ¸¦ Ã£¾Æ ¹İÈ¯
+        // Dictionaryì—ì„œ IDë¥¼ ì‚¬ìš©í•˜ì—¬ ë°ì´í„°ë¥¼ ì°¾ì•„ ë°˜í™˜
         public static T GetDataById(Dictionary<int, T> dataDictionary, int id)
         {
             T resultData;
@@ -78,7 +78,7 @@ public class DataManager<T>
             }
             else
             {
-                Debug.LogWarning("ID¿¡ ÇØ´çÇÏ´Â µ¥ÀÌÅÍ¸¦ Ã£À» ¼ö ¾ø½À´Ï´Ù.");
+                Debug.LogWarning("IDì— í•´ë‹¹í•˜ëŠ” ë°ì´í„°ë¥¼ ì°¾ì„ ìˆ˜ ì—†ìŠµë‹ˆë‹¤.");
                 return default(T);
             }
         }

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/DataManager.cs.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/DataManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32bb7d2a48cc9be44924999cc091aea9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/EventManager.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/EventManager.cs
@@ -1,4 +1,4 @@
-//System
+ï»¿//System
 using System;
 using System.Collections.Generic;
 
@@ -19,16 +19,16 @@ public class TransformEventArgs : EventArgs
 }
 
 /// <summary>
-/// ÀÌº¥Æ®¸¦ °ü¸®ÇÏ´Â ½Ì±ÛÅæ ÀÌº¥Æ® ¸Å´ÏÀú Å¬·¡½ºÀÔ´Ï´Ù.
-/// ´Ù¾çÇÑ ¿­°ÅÇü Å¸ÀÔ¿¡ ´ëÇØ ÀÌº¥Æ®¸¦ µî·ÏÇÏ°í ½ÇÇàÇÒ ¼ö ÀÖ½À´Ï´Ù.
+/// ì´ë²¤íŠ¸ë¥¼ ê´€ë¦¬í•˜ëŠ” ì‹±ê¸€í†¤ ì´ë²¤íŠ¸ ë§¤ë‹ˆì € í´ë˜ìŠ¤ì…ë‹ˆë‹¤.
+/// ë‹¤ì–‘í•œ ì—´ê±°í˜• íƒ€ì…ì— ëŒ€í•´ ì´ë²¤íŠ¸ë¥¼ ë“±ë¡í•˜ê³  ì‹¤í–‰í•  ìˆ˜ ìˆìŠµë‹ˆë‹¤.
 /// </summary>
-/// <typeparam name="TEnum">¿­°ÅÇü Å¸ÀÔ</typeparam>
+/// <typeparam name="TEnum">ì—´ê±°í˜• íƒ€ì…</typeparam>
 
 public class EventManager<TEnum> where TEnum : Enum
 {
     #region Singleton
 
-    // ½Ì±ÛÅæ ÀÎ½ºÅÏ½º
+    // ì‹±ê¸€í†¤ ì¸ìŠ¤í„´ìŠ¤
     private static EventManager<TEnum> s_Instance;
     public static EventManager<TEnum> Instance
     {
@@ -48,10 +48,10 @@ public class EventManager<TEnum> where TEnum : Enum
     private Dictionary<TEnum, List<OnEvent>> m_Listeners = new Dictionary<TEnum, List<OnEvent>>();
 
     /// <summary>
-    /// ¸®½º³Ê¸¦ Ãß°¡ÇÏ´Â ÇÔ¼ö
+    /// ë¦¬ìŠ¤ë„ˆë¥¼ ì¶”ê°€í•˜ëŠ” í•¨ìˆ˜
     /// </summary>
-    /// <param name="_eventType">ÀÌº¥Æ® Å¸ÀÔ</param>
-    /// <param name="_listener">ÀÌº¥Æ® ¸®½º³Ê</param>
+    /// <param name="_eventType">ì´ë²¤íŠ¸ íƒ€ì…</param>
+    /// <param name="_listener">ì´ë²¤íŠ¸ ë¦¬ìŠ¤ë„ˆ</param>
     public void AddListener(TEnum _eventType, OnEvent _listener)
     {
         if (!m_Listeners.TryGetValue(_eventType, out var listenList))
@@ -63,11 +63,11 @@ public class EventManager<TEnum> where TEnum : Enum
     }
 
     /// <summary>
-    /// ÀÌº¥Æ®¸¦ ¹ß»ı½ÃÅ°´Â ÇÔ¼ö
+    /// ì´ë²¤íŠ¸ë¥¼ ë°œìƒì‹œí‚¤ëŠ” í•¨ìˆ˜
     /// </summary>
-    /// <param name="_eventType">ÀÌº¥Æ® Å¸ÀÔ</param>
-    /// <param name="_sender">ÀÌº¥Æ®¸¦ ¹ß»ı½ÃÅ² °´Ã¼</param>
-    /// <param name="_args">ÀÌº¥Æ®¿Í ÇÔ²² Àü´ŞµÇ´Â Ãß°¡ µ¥ÀÌÅÍ</param>
+    /// <param name="_eventType">ì´ë²¤íŠ¸ íƒ€ì…</param>
+    /// <param name="_sender">ì´ë²¤íŠ¸ë¥¼ ë°œìƒì‹œí‚¨ ê°ì²´</param>
+    /// <param name="_args">ì´ë²¤íŠ¸ì™€ í•¨ê»˜ ì „ë‹¬ë˜ëŠ” ì¶”ê°€ ë°ì´í„°</param>
     public void PostNotification(TEnum _eventType, Component _sender, TransformEventArgs _args = null)
     {
         if (!m_Listeners.TryGetValue(_eventType, out var listenList))
@@ -80,10 +80,10 @@ public class EventManager<TEnum> where TEnum : Enum
     }
 
     /// <summary>
-    /// ¸®½º³Ê¸¦ Á¦°ÅÇÏ´Â ÇÔ¼ö
+    /// ë¦¬ìŠ¤ë„ˆë¥¼ ì œê±°í•˜ëŠ” í•¨ìˆ˜
     /// </summary>
-    /// <param name="_eventType">ÀÌº¥Æ® Å¸ÀÔ</param>
-    /// <param name="_target">Á¦°ÅÇÒ Å¸°Ù °´Ã¼</param>
+    /// <param name="_eventType">ì´ë²¤íŠ¸ íƒ€ì…</param>
+    /// <param name="_target">ì œê±°í•  íƒ€ê²Ÿ ê°ì²´</param>
     public void RemoveListener(TEnum _eventType, object _target)
     {
         if (!m_Listeners.ContainsKey(_eventType))
@@ -103,16 +103,16 @@ public class EventManager<TEnum> where TEnum : Enum
     }
 
     /// <summary>
-    /// Æ¯Á¤ ÀÌº¥Æ® Å¸ÀÔÀÇ ¸ğµç ¸®½º³Ê¸¦ Á¦°ÅÇÏ´Â ÇÔ¼ö
+    /// íŠ¹ì • ì´ë²¤íŠ¸ íƒ€ì…ì˜ ëª¨ë“  ë¦¬ìŠ¤ë„ˆë¥¼ ì œê±°í•˜ëŠ” í•¨ìˆ˜
     /// </summary>
-    /// <param name="_eventType">ÀÌº¥Æ® Å¸ÀÔ</param>
+    /// <param name="_eventType">ì´ë²¤íŠ¸ íƒ€ì…</param>
     public void RemoveEvent(TEnum _eventType)
     {
         m_Listeners.Remove(_eventType);
     }
 
     /// <summary>
-    /// null °ªÀÌ Æ÷ÇÔµÈ ¸®½º³ÊµéÀ» Á¦°ÅÇÏ´Â ÇÔ¼ö
+    /// null ê°’ì´ í¬í•¨ëœ ë¦¬ìŠ¤ë„ˆë“¤ì„ ì œê±°í•˜ëŠ” í•¨ìˆ˜
     /// </summary>
     public void RemoveRedundancies()
     {

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/EventManager.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/EventManager.cs
@@ -1,18 +1,139 @@
-using System.Collections;
+//System
+using System;
 using System.Collections.Generic;
+
+//Engine
 using UnityEngine;
 
-public class EventManager : MonoBehaviour
+
+public class TransformEventArgs : EventArgs
 {
-    // Start is called before the first frame update
-    void Start()
+    public Transform m_Transform;
+    public object[] m_Value;
+
+    public TransformEventArgs(Transform _transform, params object[] _value)
     {
-        
+        m_Transform = _transform;
+        m_Value = _value;
+    }
+}
+
+/// <summary>
+/// 이벤트를 관리하는 싱글톤 이벤트 매니저 클래스입니다.
+/// 다양한 열거형 타입에 대해 이벤트를 등록하고 실행할 수 있습니다.
+/// </summary>
+/// <typeparam name="TEnum">열거형 타입</typeparam>
+
+public class EventManager<TEnum> where TEnum : Enum
+{
+    #region Singleton
+
+    // 싱글톤 인스턴스
+    private static EventManager<TEnum> s_Instance;
+    public static EventManager<TEnum> Instance
+    {
+        get
+        {
+            if (s_Instance == null)
+            {
+                s_Instance = new EventManager<TEnum>();
+            }
+            return s_Instance;
+        }
     }
 
-    // Update is called once per frame
-    void Update()
+    #endregion
+
+    public delegate void OnEvent(TEnum _eventType, Component _sender, TransformEventArgs _args = null);
+    private Dictionary<TEnum, List<OnEvent>> m_Listeners = new Dictionary<TEnum, List<OnEvent>>();
+
+    /// <summary>
+    /// 리스너를 추가하는 함수
+    /// </summary>
+    /// <param name="_eventType">이벤트 타입</param>
+    /// <param name="_listener">이벤트 리스너</param>
+    public void AddListener(TEnum _eventType, OnEvent _listener)
     {
-        
+        if (!m_Listeners.TryGetValue(_eventType, out var listenList))
+        {
+            listenList = new List<OnEvent>();
+            m_Listeners.Add(_eventType, listenList);
+        }
+        listenList.Add(_listener);
+    }
+
+    /// <summary>
+    /// 이벤트를 발생시키는 함수
+    /// </summary>
+    /// <param name="_eventType">이벤트 타입</param>
+    /// <param name="_sender">이벤트를 발생시킨 객체</param>
+    /// <param name="_args">이벤트와 함께 전달되는 추가 데이터</param>
+    public void PostNotification(TEnum _eventType, Component _sender, TransformEventArgs _args = null)
+    {
+        if (!m_Listeners.TryGetValue(_eventType, out var listenList))
+            return;
+
+        foreach (var listener in listenList)
+        {
+            listener?.Invoke(_eventType, _sender, _args);
+        }
+    }
+
+    /// <summary>
+    /// 리스너를 제거하는 함수
+    /// </summary>
+    /// <param name="_eventType">이벤트 타입</param>
+    /// <param name="_target">제거할 타겟 객체</param>
+    public void RemoveListener(TEnum _eventType, object _target)
+    {
+        if (!m_Listeners.ContainsKey(_eventType))
+            return;
+
+        List<OnEvent> listenList = m_Listeners[_eventType];
+        for (int i = listenList.Count - 1; i >= 0; i--)
+        {
+            if (listenList[i].Target == _target)
+            {
+                listenList.RemoveAt(i);
+                Debug.Log("Event Listener Removed Successfully"); //Debug
+                return;
+            }
+        }
+        Debug.Log("Failed to Remove Event Listener"); //Debug
+    }
+
+    /// <summary>
+    /// 특정 이벤트 타입의 모든 리스너를 제거하는 함수
+    /// </summary>
+    /// <param name="_eventType">이벤트 타입</param>
+    public void RemoveEvent(TEnum _eventType)
+    {
+        m_Listeners.Remove(_eventType);
+    }
+
+    /// <summary>
+    /// null 값이 포함된 리스너들을 제거하는 함수
+    /// </summary>
+    public void RemoveRedundancies()
+    {
+        Dictionary<TEnum, List<OnEvent>> newListeners = new Dictionary<TEnum, List<OnEvent>>();
+
+        foreach (var item in m_Listeners)
+        {
+            for (int i = item.Value.Count - 1; i >= 0; i--)
+            {
+                if (item.Value[i].Equals(null))
+                {
+                    item.Value.RemoveAt(i);
+                }
+            }
+
+            if (item.Value.Count > 0)
+            {
+                newListeners.Add(item.Key, item.Value);
+            }
+        }
+
+        m_Listeners = newListeners;
     }
 }

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/GameManager.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/GameManager.cs
@@ -1,18 +1,36 @@
-using System.Collections;
-using System.Collections.Generic;
+// Engine
 using UnityEngine;
 
+/// <summary>
+/// 게임 전체를 관리하는 싱글톤 게임 매니저 클래스입니다.
+/// 다른 매니저들을 싱글톤처럼 사용하기 위해 불러오는 용도로만 최대한 활용하고 
+/// 추가적인 기능은 최대한 다른 스크립트를 활용하도록 합시다.
+/// </summary>
 public class GameManager : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    #region Singleton
+
+    private static GameManager s_Instance;
+    public static GameManager Instance
     {
-        
+        get
+        {
+            return s_Instance ?? null;
+        }
     }
 
-    // Update is called once per frame
-    void Update()
+    #endregion
+
+    private void Awake()
     {
-        
+        if (s_Instance == null)
+        {
+            s_Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
     }
 }

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/GameManager.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/01. Managers/GameManager.cs
@@ -1,10 +1,10 @@
-// Engine
+﻿// Engine
 using UnityEngine;
 
 /// <summary>
-/// ���� ��ü�� �����ϴ� �̱��� ���� �Ŵ��� Ŭ�����Դϴ�.
-/// �ٸ� �Ŵ������� �̱���ó�� ����ϱ� ���� �ҷ����� �뵵�θ� �ִ��� Ȱ���ϰ� 
-/// �߰����� ����� �ִ��� �ٸ� ��ũ��Ʈ�� Ȱ���ϵ��� �սô�.
+/// 게임 전체를 관리하는 싱글톤 게임 매니저 클래스입니다.
+/// 다른 매니저들을 싱글톤처럼 사용하기 위해 불러오는 용도로만 최대한 활용하고 
+/// 추가적인 기능은 최대한 다른 스크립트를 활용하도록 합시다.
 /// </summary>
 public class GameManager : MonoBehaviour
 {

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0edef48adc51e644bbbe4be05ffef0e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalEnumTypes.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalEnumTypes.cs
@@ -1,0 +1,18 @@
+//Engine
+using UnityEngine;
+
+namespace Utils.EnumTypes {
+
+    /// <summary>
+    /// 글로벌하게 쓰일 Enum 열거형 타입들을 모아두는 공간입니다.
+    /// </summary>
+
+    /*
+    ex)
+    public enum DPEventTypes
+    {
+        Fail, Success, None
+    }
+    */
+}
+

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalEnumTypes.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalEnumTypes.cs
@@ -1,10 +1,10 @@
-//Engine
+ï»¿//Engine
 using UnityEngine;
 
 namespace Utils.EnumTypes {
 
     /// <summary>
-    /// ±Û·Î¹úÇÏ°Ô ¾²ÀÏ Enum ¿­°ÅÇü Å¸ÀÔµéÀ» ¸ğ¾ÆµÎ´Â °ø°£ÀÔ´Ï´Ù.
+    /// ê¸€ë¡œë²Œí•˜ê²Œ ì“°ì¼ Enum ì—´ê±°í˜• íƒ€ì…ë“¤ì„ ëª¨ì•„ë‘ëŠ” ê³µê°„ì…ë‹ˆë‹¤.
     /// </summary>
 
     /*

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalEnumTypes.cs.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalEnumTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83b4e480080016646903622ab08faed4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalStructs.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalStructs.cs
@@ -1,0 +1,20 @@
+//Engine
+using UnityEngine;
+
+namespace Utils.Structs
+{
+
+    /// <summary>
+    /// 글로벌하게 쓰일 Structs 구조체들을 모아두는 공간입니다.
+    /// </summary>
+
+    /*
+    ex)
+    [Serializable]
+	public struct AttackData
+	{
+        //..
+	}
+    */
+}
+

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalStructs.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalStructs.cs
@@ -1,11 +1,11 @@
-//Engine
+ï»¿//Engine
 using UnityEngine;
 
 namespace Utils.Structs
 {
 
     /// <summary>
-    /// ±Û·Î¹úÇÏ°Ô ¾²ÀÏ Structs ±¸Á¶Ã¼µéÀ» ¸ğ¾ÆµÎ´Â °ø°£ÀÔ´Ï´Ù.
+    /// ê¸€ë¡œë²Œí•˜ê²Œ ì“°ì¼ Structs êµ¬ì¡°ì²´ë“¤ì„ ëª¨ì•„ë‘ëŠ” ê³µê°„ì…ë‹ˆë‹¤.
     /// </summary>
 
     /*

--- a/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalStructs.cs.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/00. Common/02. Utils/GlobalStructs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1186271e3d5e726448621b0e3e2a9d72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/01. Jumak/00. Character/Customer/Customer.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/01. Jumak/00. Character/Customer/Customer.cs
@@ -1,4 +1,4 @@
-//Engine
+﻿//Engine
 using UnityEngine;
 
 //Interface

--- a/Dungeon Jumak/Assets/00. Scripts/01. Jumak/00. Character/Player_Jumak/JumakPlayer.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/01. Jumak/00. Character/Player_Jumak/JumakPlayer.cs
@@ -1,4 +1,4 @@
-//Engine
+﻿//Engine
 using UnityEngine;
 
 //Interface

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_AnimationHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_AnimationHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_AudioHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_AudioHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_EventHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_EventHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_MoveHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Handler/MO_MoveHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Monster.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Monster.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using Interfaces;
 
 //Ect
-using Data.Monster;
+using Data.Character;
 
 public class Monster : IDamageable, ITurnable, IMovable
 {

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Monster.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Monster/Monster.cs
@@ -1,4 +1,4 @@
-//Engine
+﻿//Engine
 using UnityEngine;
 
 //Interface

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/DunjeonPlayer.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/DunjeonPlayer.cs
@@ -1,4 +1,4 @@
-//Engine
+﻿//Engine
 using UnityEngine;
 
 //Interface

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_AnimationHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_AnimationHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_EventHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_EventHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_EventHandler1.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_EventHandler1.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_MoveHandler.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/02. Dungeon/00. Character/Player_Dunjeon/Handler/DP_MoveHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Monster/MonsterData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Monster/MonsterData_Base.cs
@@ -1,4 +1,4 @@
-//Engine
+ï»¿//Engine
 using UnityEngine;
 
 namespace Data.Character
@@ -6,24 +6,24 @@ namespace Data.Character
     [CreateAssetMenu(fileName = "MonsterData", menuName = "Scriptable/Character/Monster")]
     public class MonsterData_Base : ScriptableObject
     {
-        [Header("¸ó½ºÅÍ Á¤º¸")]
-        [Tooltip("¸ó½ºÅÍÀÇ ÀÌ¸§À» ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Header("ëª¬ìŠ¤í„° ì •ë³´")]
+        [Tooltip("ëª¬ìŠ¤í„°ì˜ ì´ë¦„ì„ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private string m_name;
 
         [Space(10)]
-        [Header("ÀüÅõ ½ºÅÈ")]
-        [Tooltip("¸ó½ºÅÍ°¡ ÇÃ·¹ÀÌ¾î¿¡°Ô °¡ÇÏ´Â °ø°İ µ¥¹ÌÁö ¼öÄ¡¸¦ ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Header("ì „íˆ¬ ìŠ¤íƒ¯")]
+        [Tooltip("ëª¬ìŠ¤í„°ê°€ í”Œë ˆì´ì–´ì—ê²Œ ê°€í•˜ëŠ” ê³µê²© ë°ë¯¸ì§€ ìˆ˜ì¹˜ë¥¼ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private float m_attackDamage;
 
-        [Tooltip("¸ó½ºÅÍÀÇ Ã¼·Â(HP)¸¦ ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Tooltip("ëª¬ìŠ¤í„°ì˜ ì²´ë ¥(HP)ë¥¼ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private float m_hp;
 
-        [Tooltip("¸ó½ºÅÍ Ã³Ä¡ ½Ã ÇÃ·¹ÀÌ¾î¿¡°Ô Á¦°øÇÏ´Â °æÇèÄ¡(XP)¸¦ ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Tooltip("ëª¬ìŠ¤í„° ì²˜ì¹˜ ì‹œ í”Œë ˆì´ì–´ì—ê²Œ ì œê³µí•˜ëŠ” ê²½í—˜ì¹˜(XP)ë¥¼ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private float m_xp;
 
         [Space(10)]
-        [Header("ÀÌµ¿ ½ºÅÈ")]
-        [Tooltip("¸ó½ºÅÍÀÇ ÀÌµ¿ ¼Óµµ¸¦ ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Header("ì´ë™ ìŠ¤íƒ¯")]
+        [Tooltip("ëª¬ìŠ¤í„°ì˜ ì´ë™ ì†ë„ë¥¼ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private float m_speed;
 
         public string MonsterName { get { return m_name; } }

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Monster/MonsterData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Monster/MonsterData_Base.cs
@@ -1,14 +1,14 @@
 //Engine
 using UnityEngine;
 
-namespace Data.Monster
+namespace Data.Character
 {
-    [CreateAssetMenu(fileName = "MonsterData", menuName = "Scriptable/Monster")]
+    [CreateAssetMenu(fileName = "MonsterData", menuName = "Scriptable/Character/Monster")]
     public class MonsterData_Base : ScriptableObject
     {
         [Header("몬스터 정보")]
         [Tooltip("몬스터의 이름을 설정합니다.")]
-        [SerializeField] private string m_monsterName;
+        [SerializeField] private string m_name;
 
         [Space(10)]
         [Header("전투 스탯")]
@@ -26,7 +26,7 @@ namespace Data.Monster
         [Tooltip("몬스터의 이동 속도를 설정합니다.")]
         [SerializeField] private float m_speed;
 
-        public string MonsterName { get { return m_monsterName; } }
+        public string MonsterName { get { return m_name; } }
         public float Damage { get { return m_attackDamage; } }
         public float Hp { get { return m_hp; } }
         public float Xp { get { return m_xp; } }

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Dunjeon/DunjeonPlayerData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Dunjeon/DunjeonPlayerData_Base.cs
@@ -1,7 +1,7 @@
 //Engine
 using UnityEngine;
 
-namespace Data.Player
+namespace Data.Character
 {
     [CreateAssetMenu(fileName = "DunjeonPlayerData", menuName = "Scriptable/Character/Player/DunjeonPlayer")]
     public class DunjeonPlayerData_Base : ScriptableObject

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Dunjeon/DunjeonPlayerData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Dunjeon/DunjeonPlayerData_Base.cs
@@ -1,4 +1,4 @@
-//Engine
+﻿//Engine
 using UnityEngine;
 
 namespace Data.Character

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Jumak/JumakPlayerData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Jumak/JumakPlayerData_Base.cs
@@ -1,4 +1,4 @@
-//Engine
+﻿//Engine
 using UnityEngine;
 
 namespace Data.Character

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Jumak/JumakPlayerData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/00. Character/Player_Jumak/JumakPlayerData_Base.cs
@@ -1,7 +1,7 @@
 //Engine
 using UnityEngine;
 
-namespace Data.Player
+namespace Data.Character
 {
     [CreateAssetMenu(fileName = "JumakPlayerData", menuName = "Scriptable/Character/Player/JumakPlayer")]
     public class JumakPlayerData_Base : ScriptableObject

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c32812077ed70648b519f6ebd942d64
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92a16bc6868b61a44a2766967f61da79
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.asset
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8c04f32591de3541be970edef90454f, type: 3}
+  m_Name: ItemData_Base
+  m_EditorClassIdentifier: 
+  m_name: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.asset.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59e6e1570b6d02e42ac5b1e22ae6ebd8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.cs
@@ -1,0 +1,13 @@
+//Engine
+using UnityEngine;
+
+namespace Data.Object
+{
+    [CreateAssetMenu(fileName = "ItemData", menuName = "Scriptable/Item")]
+    public class ItemData_Base : ScriptableObject
+    {
+        [Header("아이템 정보")]
+        [Tooltip("아이템의 이름을 설정합니다.")]
+        [SerializeField] private string m_name;
+    }
+}

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.cs
@@ -1,4 +1,4 @@
-//Engine
+ï»¿//Engine
 using UnityEngine;
 
 namespace Data.Object
@@ -6,8 +6,8 @@ namespace Data.Object
     [CreateAssetMenu(fileName = "ItemData", menuName = "Scriptable/Item")]
     public class ItemData_Base : ScriptableObject
     {
-        [Header("¾ÆÀÌÅÛ Á¤º¸")]
-        [Tooltip("¾ÆÀÌÅÛÀÇ ÀÌ¸§À» ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Header("ì•„ì´í…œ ì •ë³´")]
+        [Tooltip("ì•„ì´í…œì˜ ì´ë¦„ì„ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private string m_name;
     }
 }

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.cs.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Items/ItemData_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8c04f32591de3541be970edef90454f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f1470da47ed0db45b6fa9c01bbe309e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.asset
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 922c31fafef32464db6d3b96ce12d8cc, type: 3}
+  m_Name: SkillData_Base
+  m_EditorClassIdentifier: 
+  m_name: 
+  m_attackDamage: 0

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.asset.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e13e90869e4f5544a2298c5610f7dd4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.cs
@@ -1,4 +1,4 @@
-//Engine
+ï»¿//Engine
 using UnityEngine;
 
 namespace Data.Object
@@ -6,11 +6,11 @@ namespace Data.Object
     [CreateAssetMenu(fileName = "SkillData", menuName = "Scriptable/Skill")]
     public class SkillData_Base : ScriptableObject
     {
-        [Header("½ºÅ³ Á¤º¸")]
-        [Tooltip("½ºÅ³ÀÇ ÀÌ¸§À» ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Header("ìŠ¤í‚¬ ì •ë³´")]
+        [Tooltip("ìŠ¤í‚¬ì˜ ì´ë¦„ì„ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private string m_name;
 
-        [Tooltip("½ºÅ³ÀÌ ¸ó½ºÅÍ¿¡°Ô °¡ÇÏ´Â °ø°İ µ¥¹ÌÁö ¼öÄ¡¸¦ ¼³Á¤ÇÕ´Ï´Ù.")]
+        [Tooltip("ìŠ¤í‚¬ì´ ëª¬ìŠ¤í„°ì—ê²Œ ê°€í•˜ëŠ” ê³µê²© ë°ë¯¸ì§€ ìˆ˜ì¹˜ë¥¼ ì„¤ì •í•©ë‹ˆë‹¤.")]
         [SerializeField] private float m_attackDamage;
     }
 }

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.cs
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.cs
@@ -1,0 +1,16 @@
+//Engine
+using UnityEngine;
+
+namespace Data.Object
+{
+    [CreateAssetMenu(fileName = "SkillData", menuName = "Scriptable/Skill")]
+    public class SkillData_Base : ScriptableObject
+    {
+        [Header("스킬 정보")]
+        [Tooltip("스킬의 이름을 설정합니다.")]
+        [SerializeField] private string m_name;
+
+        [Tooltip("스킬이 몬스터에게 가하는 공격 데미지 수치를 설정합니다.")]
+        [SerializeField] private float m_attackDamage;
+    }
+}

--- a/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.cs.meta
+++ b/Dungeon Jumak/Assets/00. Scripts/99. Data/01. Objects/Skills/SkillData_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 922c31fafef32464db6d3b96ce12d8cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dungeon Jumak/Packages/manifest.json
+++ b/Dungeon Jumak/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.marijnzwemmer.unity-toolbar-extender": "https://github.com/marijnz/unity-toolbar-extender.git",
+    "com.unity.addressables": "1.19.19",
     "com.unity.collab-proxy": "1.17.7",
     "com.unity.feature.2d": "1.0.0",
     "com.unity.feature.mobile": "1.0.0",

--- a/Dungeon Jumak/Packages/packages-lock.json
+++ b/Dungeon Jumak/Packages/packages-lock.json
@@ -109,6 +109,20 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.addressables": {
+      "version": "1.19.19",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.scriptablebuildpipeline": "1.19.6",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
       "version": "1.6.6",
       "depth": 3,
@@ -216,6 +230,13 @@
     "com.unity.profiling.core": {
       "version": "1.0.2",
       "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.scriptablebuildpipeline": {
+      "version": "1.20.1",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"


### PR DESCRIPTION
## 🔎 작업 내용

- Addressable 패키지 install

*** 하단의 스크립트들은 다 꼼꼼히 확인해보고 구조 파악해주세요. 의견이나 수정 예정 등등 매니저 코드 관련해서 지속해서 대화하며 구조 잡아나가는 게 좋을 것 같습니다 ***

- DataManager, EventManager(싱글톤), GameManager(싱글톤) 매니저 코드 작성
- Asset/Common/Utils 폴더 내부에 글로벌하게 사용할 Enumtype들과 Struct들 모아둘 스크립트 생성

*** 스크립터블 오브젝트나 객체 데이터 쪽은 시스템 잡아나가며 차근차근 수정해야 할 것 같아요. ***

- Item, Skill 스크립터블 오브젝트 생성

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/c4f771b2-c763-41e5-863b-d3c80ab9c63d)

<br/>

## 🔧 앞으로의 과제

- DataManager 활용한 데이터 활용 방안 설계 후 구현

  <br/>

## ➕ 이슈 링크

Fixes #11 

<br/>
